### PR TITLE
Fix that links in comments cannot be invoked by touch.

### DIFF
--- a/ExViewer/App.xaml
+++ b/ExViewer/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="ExViewer.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <Application.Resources>
+    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <muxc:XamlControlsResources xmlns:muxc="using:Microsoft.UI.Xaml.Controls" />

--- a/ExViewer/App.xaml
+++ b/ExViewer/App.xaml
@@ -2,26 +2,29 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Application.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-        <ResourceDictionary Source="Themes/GenericOverride.xaml" />
-        <ResourceDictionary Source="Themes/NamedStyles.xaml" />
-        <ResourceDictionary Source="Converters/Converters.xaml" />
-        <!--DO NOT CHANGE THE ORDER OF FOLLOWING TWO DICTIONARY-->
-        <ResourceDictionary Source="Strings/FallbackDictionary.xaml" />
-        <ResourceDictionary Source="Strings/Dictionary.xaml" />
-        <!--DO NOT CHANGE THE ORDER OF PREVIOUS TWO DICTIONARY-->
-      </ResourceDictionary.MergedDictionaries>
-      <ResourceDictionary.ThemeDictionaries>
-        <ResourceDictionary x:Key="Dark"
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <muxc:XamlControlsResources xmlns:muxc="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary>
+                    <x:Boolean x:Key="HyperlinkUnderlineVisible">True</x:Boolean>
+                </ResourceDictionary>
+                <ResourceDictionary Source="Themes/GenericOverride.xaml" />
+                <ResourceDictionary Source="Themes/NamedStyles.xaml" />
+                <ResourceDictionary Source="Converters/Converters.xaml" />
+                <!--DO NOT CHANGE THE ORDER OF FOLLOWING TWO DICTIONARY-->
+                <ResourceDictionary Source="Strings/FallbackDictionary.xaml" />
+                <ResourceDictionary Source="Strings/Dictionary.xaml" />
+                <!--DO NOT CHANGE THE ORDER OF PREVIOUS TWO DICTIONARY-->
+            </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Dark"
                             Source="Themes/Dark.xaml" />
-        <ResourceDictionary x:Key="Light"
+                <ResourceDictionary x:Key="Light"
                             Source="Themes/Light.xaml" />
-      </ResourceDictionary.ThemeDictionaries>
-      <Color x:Key="SplashColor">#ffe7dfca</Color>
-      <SolidColorBrush x:Key="SplashBrush"
+            </ResourceDictionary.ThemeDictionaries>
+            <Color x:Key="SplashColor">#ffe7dfca</Color>
+            <SolidColorBrush x:Key="SplashBrush"
                        Color="{StaticResource SplashColor}" />
-    </ResourceDictionary>
-  </Application.Resources>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/ExViewer/App.xaml
+++ b/ExViewer/App.xaml
@@ -1,30 +1,30 @@
 ﻿<Application x:Class="ExViewer.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Application.Resources>
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <muxc:XamlControlsResources xmlns:muxc="using:Microsoft.UI.Xaml.Controls" />
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <muxc:XamlControlsResources xmlns:muxc="using:Microsoft.UI.Xaml.Controls" />
-                <ResourceDictionary>
-                    <x:Boolean x:Key="HyperlinkUnderlineVisible">True</x:Boolean>
-                </ResourceDictionary>
-                <ResourceDictionary Source="Themes/GenericOverride.xaml" />
-                <ResourceDictionary Source="Themes/NamedStyles.xaml" />
-                <ResourceDictionary Source="Converters/Converters.xaml" />
-                <!--DO NOT CHANGE THE ORDER OF FOLLOWING TWO DICTIONARY-->
-                <ResourceDictionary Source="Strings/FallbackDictionary.xaml" />
-                <ResourceDictionary Source="Strings/Dictionary.xaml" />
-                <!--DO NOT CHANGE THE ORDER OF PREVIOUS TWO DICTIONARY-->
-            </ResourceDictionary.MergedDictionaries>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Dark"
-                            Source="Themes/Dark.xaml" />
-                <ResourceDictionary x:Key="Light"
-                            Source="Themes/Light.xaml" />
-            </ResourceDictionary.ThemeDictionaries>
-            <Color x:Key="SplashColor">#ffe7dfca</Color>
-            <SolidColorBrush x:Key="SplashBrush"
-                       Color="{StaticResource SplashColor}" />
+          <x:Boolean x:Key="HyperlinkUnderlineVisible">True</x:Boolean>
         </ResourceDictionary>
-    </Application.Resources>
+        <ResourceDictionary Source="Themes/GenericOverride.xaml" />
+        <ResourceDictionary Source="Themes/NamedStyles.xaml" />
+        <ResourceDictionary Source="Converters/Converters.xaml" />
+        <!--DO NOT CHANGE THE ORDER OF FOLLOWING TWO DICTIONARY-->
+        <ResourceDictionary Source="Strings/FallbackDictionary.xaml" />
+        <ResourceDictionary Source="Strings/Dictionary.xaml" />
+        <!--DO NOT CHANGE THE ORDER OF PREVIOUS TWO DICTIONARY-->
+      </ResourceDictionary.MergedDictionaries>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark"
+                            Source="Themes/Dark.xaml" />
+        <ResourceDictionary x:Key="Light"
+                            Source="Themes/Light.xaml" />
+      </ResourceDictionary.ThemeDictionaries>
+      <Color x:Key="SplashColor">#ffe7dfca</Color>
+      <SolidColorBrush x:Key="SplashBrush"
+                       Color="{StaticResource SplashColor}" />
+    </ResourceDictionary>
+  </Application.Resources>
 </Application>


### PR DESCRIPTION
Fix the issue according to the workaround on the following issue.
[RichTextBlock hyperlinks do not work with touch on Windows 11](https://github.com/microsoft/microsoft-ui-xaml/issues/6513)

The links are a little bit hard to be tapped since all the comments in the list will bounce to right and back when I touch the comment list, which causes the interaction on links unstable.
